### PR TITLE
fix: stabilize VOD audio track switching

### DIFF
--- a/.github/workflows/ffmpeg-sidecar.yml
+++ b/.github/workflows/ffmpeg-sidecar.yml
@@ -20,8 +20,7 @@ name: ffmpeg Sidecar
 #
 # No GPL, no nonfree, no external libraries: LGPL configure only. See
 # ffmpeg.md for the full rationale.
-# H.264/HEVC decoders are retained for Matroska timestamp probing; the video
-# itself is still stream-copied and never re-encoded by the app.
+# H.264/HEVC decoders exist only for Matroska timestamp probing; video is never re-encoded.
 
 on:
   push:
@@ -152,7 +151,7 @@ jobs:
             echo "workflow commit: ${GITHUB_SHA}"
             echo
             echo "configure line:"
-            echo "./configure --target-os=mingw32 --arch=x86_64 --disable-everything --disable-autodetect --enable-network --disable-doc --disable-debug --disable-ffplay --disable-ffprobe --disable-avdevice --disable-postproc --enable-protocol=pipe,http,tcp --enable-demuxer=mpegts,matroska,mov --enable-muxer=mpegts --enable-decoder=aac --enable-decoder=aac_latm --enable-decoder=ac3 --enable-decoder=eac3 --enable-decoder=mp2 --enable-decoder=mp3 --enable-decoder=dca --enable-decoder=opus --enable-decoder=vorbis --enable-decoder=flac --enable-decoder=truehd --enable-decoder=pcm_s16le --enable-encoder=aac --enable-parser=h264 --enable-parser=hevc --enable-parser=mpegvideo --enable-parser=mpegaudio --enable-parser=aac --enable-parser=aac_latm --enable-parser=ac3 --enable-parser=dca --enable-filter=aresample --enable-filter=aformat --enable-filter=anull --enable-bsf=extract_extradata --enable-bsf=h264_mp4toannexb --enable-bsf=hevc_mp4toannexb --enable-bsf=aac_adtstoasc --enable-zlib --extra-ldflags=-static --pkg-config-flags=--static"
+            echo "./configure --target-os=mingw32 --arch=x86_64 --disable-everything --disable-autodetect --enable-network --disable-doc --disable-debug --disable-ffplay --disable-ffprobe --disable-avdevice --disable-postproc --enable-protocol=pipe,http,tcp --enable-demuxer=mpegts,matroska,mov --enable-muxer=mpegts --enable-decoder=aac --enable-decoder=aac_latm --enable-decoder=ac3 --enable-decoder=eac3 --enable-decoder=mp2 --enable-decoder=mp3 --enable-decoder=dca --enable-decoder=opus --enable-decoder=vorbis --enable-decoder=flac --enable-decoder=truehd --enable-decoder=pcm_s16le --enable-decoder=h264 --enable-decoder=hevc --enable-encoder=aac --enable-parser=h264 --enable-parser=hevc --enable-parser=mpegvideo --enable-parser=mpegaudio --enable-parser=aac --enable-parser=aac_latm --enable-parser=ac3 --enable-parser=dca --enable-filter=aresample --enable-filter=aformat --enable-filter=anull --enable-bsf=extract_extradata --enable-bsf=h264_mp4toannexb --enable-bsf=hevc_mp4toannexb --enable-bsf=aac_adtstoasc --enable-zlib --extra-ldflags=-static --pkg-config-flags=--static"
           } > stage/BUILD-INFO-windows.txt
 
       - name: Verify standalone binary outside MSYS2
@@ -268,7 +267,7 @@ jobs:
             echo "workflow commit: ${GITHUB_SHA}"
             echo
             echo "configure line:"
-            echo "./configure --disable-everything --disable-autodetect --enable-network --disable-doc --disable-debug --disable-ffplay --disable-ffprobe --disable-avdevice --disable-postproc --enable-protocol=pipe,http,tcp --enable-demuxer=mpegts,matroska,mov --enable-muxer=mpegts --enable-decoder=aac --enable-decoder=aac_latm --enable-decoder=ac3 --enable-decoder=eac3 --enable-decoder=mp2 --enable-decoder=mp3 --enable-decoder=dca --enable-decoder=opus --enable-decoder=vorbis --enable-decoder=flac --enable-decoder=truehd --enable-decoder=pcm_s16le --enable-encoder=aac --enable-parser=h264 --enable-parser=hevc --enable-parser=mpegvideo --enable-parser=mpegaudio --enable-parser=aac --enable-parser=aac_latm --enable-parser=ac3 --enable-parser=dca --enable-filter=aresample --enable-filter=aformat --enable-filter=anull --enable-bsf=extract_extradata --enable-bsf=h264_mp4toannexb --enable-bsf=hevc_mp4toannexb --enable-bsf=aac_adtstoasc --enable-zlib --pkg-config-flags=--static"
+            echo "./configure --disable-everything --disable-autodetect --enable-network --disable-doc --disable-debug --disable-ffplay --disable-ffprobe --disable-avdevice --disable-postproc --enable-protocol=pipe,http,tcp --enable-demuxer=mpegts,matroska,mov --enable-muxer=mpegts --enable-decoder=aac --enable-decoder=aac_latm --enable-decoder=ac3 --enable-decoder=eac3 --enable-decoder=mp2 --enable-decoder=mp3 --enable-decoder=dca --enable-decoder=opus --enable-decoder=vorbis --enable-decoder=flac --enable-decoder=truehd --enable-decoder=pcm_s16le --enable-decoder=h264 --enable-decoder=hevc --enable-encoder=aac --enable-parser=h264 --enable-parser=hevc --enable-parser=mpegvideo --enable-parser=mpegaudio --enable-parser=aac --enable-parser=aac_latm --enable-parser=ac3 --enable-parser=dca --enable-filter=aresample --enable-filter=aformat --enable-filter=anull --enable-bsf=extract_extradata --enable-bsf=h264_mp4toannexb --enable-bsf=hevc_mp4toannexb --enable-bsf=aac_adtstoasc --enable-zlib --pkg-config-flags=--static"
           } > stage/BUILD-INFO-linux.txt
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ffmpeg-sidecar.yml
+++ b/.github/workflows/ffmpeg-sidecar.yml
@@ -20,6 +20,8 @@ name: ffmpeg Sidecar
 #
 # No GPL, no nonfree, no external libraries: LGPL configure only. See
 # ffmpeg.md for the full rationale.
+# H.264/HEVC decoders are retained for Matroska timestamp probing; the video
+# itself is still stream-copied and never re-encoded by the app.
 
 on:
   push:
@@ -92,6 +94,8 @@ jobs:
             --enable-decoder=flac \
             --enable-decoder=truehd \
             --enable-decoder=pcm_s16le \
+            --enable-decoder=h264 \
+            --enable-decoder=hevc \
             --enable-encoder=aac \
             --enable-parser=h264 \
             --enable-parser=hevc \
@@ -128,6 +132,8 @@ jobs:
             exit 1
           fi
           ./ffmpeg.exe -decoders | grep -i eac3
+          ./ffmpeg.exe -decoders | grep -w h264
+          ./ffmpeg.exe -decoders | grep -w hevc
           ./ffmpeg.exe -encoders | grep -w aac
           ls -lh ffmpeg.exe
 
@@ -204,6 +210,8 @@ jobs:
             --enable-decoder=flac \
             --enable-decoder=truehd \
             --enable-decoder=pcm_s16le \
+            --enable-decoder=h264 \
+            --enable-decoder=hevc \
             --enable-encoder=aac \
             --enable-parser=h264 \
             --enable-parser=hevc \
@@ -239,6 +247,8 @@ jobs:
             exit 1
           fi
           ./ffmpeg -decoders | grep -i eac3
+          ./ffmpeg -decoders | grep -w h264
+          ./ffmpeg -decoders | grep -w hevc
           ./ffmpeg -encoders | grep -w aac
           ls -lh ffmpeg
 
@@ -318,7 +328,7 @@ jobs:
             echo
             echo "Configure line:"
             echo '```'
-            echo "./configure --disable-everything --disable-autodetect --enable-network --disable-doc --disable-debug --disable-ffplay --disable-ffprobe --disable-avdevice --disable-postproc --enable-protocol=pipe,http,tcp --enable-demuxer=mpegts,matroska,mov --enable-muxer=mpegts --enable-decoder=aac,aac_latm,ac3,eac3,mp2,mp3,dca,opus,vorbis,flac,truehd,pcm_s16le --enable-encoder=aac --enable-parser=h264,hevc,mpegvideo,mpegaudio,aac,aac_latm,ac3,dca --enable-filter=aresample,aformat,anull --enable-bsf=extract_extradata,h264_mp4toannexb,hevc_mp4toannexb,aac_adtstoasc --enable-zlib"
+            echo "./configure --disable-everything --disable-autodetect --enable-network --disable-doc --disable-debug --disable-ffplay --disable-ffprobe --disable-avdevice --disable-postproc --enable-protocol=pipe,http,tcp --enable-demuxer=mpegts,matroska,mov --enable-muxer=mpegts --enable-decoder=aac,aac_latm,ac3,eac3,mp2,mp3,dca,opus,vorbis,flac,truehd,pcm_s16le,h264,hevc --enable-encoder=aac --enable-parser=h264,hevc,mpegvideo,mpegaudio,aac,aac_latm,ac3,dca --enable-filter=aresample,aformat,anull --enable-bsf=extract_extradata,h264_mp4toannexb,hevc_mp4toannexb,aac_adtstoasc --enable-zlib"
             echo '```'
             echo "(each comma-separated group above is repeated once per value in the actual build - see BUILD-INFO-windows.txt / BUILD-INFO-linux.txt attached below for the exact per-platform command.)"
             echo

--- a/src-tauri/src/vod_audio_proxy.rs
+++ b/src-tauri/src/vod_audio_proxy.rs
@@ -17,6 +17,8 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use tokio::process::{Child, Command as TokioCommand};
 use tokio::sync::{mpsc, oneshot, Notify};
 
+use crate::external_player;
+
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
@@ -27,7 +29,7 @@ const OUTPUT_CHANNEL_CAPACITY: usize = 256;
 const STDERR_RING_CAPACITY: usize = 10;
 const STARTUP_SILENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const STDOUT_STALL_TIMEOUT: Duration = Duration::from_secs(20);
-const CLIENT_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(10);
+const CLIENT_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(60);
 const STALL_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 // --- State ---
@@ -36,13 +38,15 @@ type ActiveSlot = Arc<Mutex<Option<Arc<VodAudioSession>>>>;
 // Keyed by id so the forward route and unregister can find a session directly.
 type SessionMap = Arc<Mutex<HashMap<String, Arc<VodAudioSession>>>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct FfmpegProbe {
     path: String,
-    demuxers_ok: bool,
-    // Matroska commonly omits video DTS; these decoders let FFmpeg infer the
-    // H.264/HEVC reorder delay while probing before stream-copying the video.
-    video_decoders_ok: bool,
+}
+
+struct CachedProbeResolution {
+    custom_path: Option<String>,
+    // None = cached "no capable ffmpeg found".
+    probe: Option<FfmpegProbe>,
 }
 
 struct ServerHandle {
@@ -56,7 +60,7 @@ pub struct VodAudioProxyState {
     server: Mutex<Option<ServerHandle>>,
     active: ActiveSlot,
     sessions: SessionMap,
-    probe: Mutex<Option<FfmpegProbe>>,
+    probe: Mutex<Option<CachedProbeResolution>>,
     // Serializes teardown -> spawn -> activate so a lost race can't orphan ffmpeg.
     register_lock: tokio::sync::Mutex<()>,
 }
@@ -67,9 +71,11 @@ struct VodAudioSession {
     user_agent: Option<String>,
     authorization: Option<String>,
     torn_down: AtomicBool,
+    // Client-timeout marker; makes the watchdog emit the error.
+    client_gone: AtomicBool,
     // New GET replaces the previous client's sender.
     current_client: Mutex<Option<mpsc::Sender<Bytes>>>,
-    // Wakes stdout delivery when the first client connects or a GET replaces it.
+    // Wakes stdout delivery on client connect or replace.
     client_notify: Notify,
     stderr_tail: Mutex<VecDeque<String>>,
     // Held only until run_watchdog takes ownership.
@@ -89,12 +95,9 @@ struct VodAudioSession {
 // --- Commands ---
 
 #[tauri::command]
-pub async fn vod_audio_remux_available(app: AppHandle) -> bool {
+pub async fn vod_audio_remux_available(app: AppHandle, ffmpeg_path: Option<String>) -> bool {
     let state = app.state::<VodAudioProxyState>();
-    ensure_probed(&state)
-        .await
-        .map(|probe| probe.demuxers_ok && probe.video_decoders_ok)
-        .unwrap_or(false)
+    ensure_probed(&state, ffmpeg_path).await.is_some()
 }
 
 #[derive(Debug, Serialize)]
@@ -114,6 +117,7 @@ pub async fn register_vod_audio_remux(
     audio_stream_index: u32,
     start_seconds: f64,
     transcode_audio: bool,
+    ffmpeg_path: Option<String>,
 ) -> Result<RegisterVodAudioRemuxResponse, String> {
     let parsed = tauri::Url::parse(&url).map_err(|e| format!("OTHER:{e}"))?;
     if parsed.scheme() != "http" && parsed.scheme() != "https" {
@@ -128,7 +132,7 @@ pub async fn register_vod_audio_remux(
     // One live session at a time; tear down before starting the next.
     teardown_active_session(&state).await;
 
-    let ffmpeg_path = match ensure_probed(&state).await {
+    let resolved_ffmpeg_path = match ensure_probed(&state, ffmpeg_path).await {
         Some(probe) => probe.path,
         None => {
             return Err(
@@ -147,6 +151,7 @@ pub async fn register_vod_audio_remux(
         user_agent: if is_loopback { None } else { user_agent },
         authorization: if is_loopback { None } else { authorization },
         torn_down: AtomicBool::new(false),
+        client_gone: AtomicBool::new(false),
         current_client: Mutex::new(None),
         client_notify: Notify::new(),
         stderr_tail: Mutex::new(VecDeque::new()),
@@ -168,7 +173,7 @@ pub async fn register_vod_audio_remux(
     };
     let ffmpeg_args = build_ffmpeg_args(&input_url, audio_stream_index, start_seconds, transcode_audio);
 
-    let mut command = TokioCommand::new(&ffmpeg_path);
+    let mut command = TokioCommand::new(&resolved_ffmpeg_path);
     command
         .args(&ffmpeg_args)
         .stdin(Stdio::null())
@@ -336,10 +341,7 @@ fn build_ffmpeg_args(input_url: &str, audio_stream_index: u32, start_seconds: f6
         "-loglevel".to_string(),
         "warning".to_string(),
     ];
-    // -ss must precede -i for input seeking. The video is stream-copied, so
-    // preserve its keyframe pre-roll in transcoded audio as well. Otherwise
-    // accurate seeking drops that pre-roll only from audio and leaves the MSE
-    // player correcting a multi-second A/V timestamp gap after a track switch.
+    // -noaccurate_seek keeps audio pre-roll aligned with the copied video.
     if start_seconds > 0.1 {
         args.push("-noaccurate_seek".to_string());
         args.push("-ss".to_string());
@@ -447,10 +449,7 @@ fn ffmpeg_candidates() -> Vec<String> {
         }
     }
 
-    // Cargo/Tauri prepend their target directory to PATH in development. A
-    // stale local sidecar there can shadow a decoder-capable system ffmpeg;
-    // enumerate every PATH entry so capability probing can continue to the
-    // next match instead of stopping at the shadowing executable.
+    // A dev-mode sidecar can shadow a capable system ffmpeg on PATH.
     if let Some(path_var) = std::env::var_os("PATH") {
         let binary_name = if cfg!(windows) {
             "ffmpeg.exe"
@@ -462,8 +461,7 @@ fn ffmpeg_candidates() -> Vec<String> {
         }
     }
 
-    // Keep the bare command as a final fallback for platforms where PATH
-    // lookup is virtual or the environment changes between probes.
+    // Bare fallback for virtual PATH lookups.
     push_candidate("ffmpeg".to_string());
     candidates
 }
@@ -523,46 +521,78 @@ async fn probe_decoders(path: &str) -> Result<String, String> {
     }
 }
 
-async fn resolve_and_probe_ffmpeg() -> Option<FfmpegProbe> {
+async fn probe_candidate(path: &str) -> Option<FfmpegProbe> {
+    let demuxers_stdout = probe_demuxers(path).await.ok()?;
+    if !demuxers_support_matroska_and_mov(&demuxers_stdout) {
+        return None;
+    }
+    // Matroska often omits video DTS; decoders let ffmpeg infer it.
+    if !probe_decoders(path)
+        .await
+        .map(|stdout| decoders_support_video_timestamp_inference(&stdout))
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    Some(FfmpegProbe {
+        path: path.to_string(),
+    })
+}
+
+fn normalize_custom_path(path: Option<String>) -> Option<String> {
+    path.map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+async fn resolve_and_probe_ffmpeg(custom_path: Option<&str>) -> Option<FfmpegProbe> {
+    if let Some(custom) = custom_path {
+        if external_player::validate_arg(custom, "ffmpeg path").is_ok() {
+            if let Some(probe) = probe_candidate(custom).await {
+                return Some(probe);
+            }
+        }
+    }
     for candidate in ffmpeg_candidates() {
-        let Ok(demuxers_stdout) = probe_demuxers(&candidate).await else {
-            continue;
-        };
-        let demuxers_ok = demuxers_support_matroska_and_mov(&demuxers_stdout);
-        let video_decoders_ok = probe_decoders(&candidate)
-            .await
-            .map(|stdout| decoders_support_video_timestamp_inference(&stdout))
-            .unwrap_or(false);
-        let probe = FfmpegProbe {
-            path: candidate,
-            demuxers_ok,
-            video_decoders_ok,
-        };
-        if demuxers_ok && video_decoders_ok {
+        if let Some(probe) = probe_candidate(&candidate).await {
             return Some(probe);
         }
     }
     None
 }
 
-async fn ensure_probed(state: &VodAudioProxyState) -> Option<FfmpegProbe> {
+// Outer None is a miss; Some(None) is a cached negative.
+fn cached_probe_hit(
+    cached: &Option<CachedProbeResolution>,
+    normalized_custom: &Option<String>,
+) -> Option<Option<FfmpegProbe>> {
+    let cache = cached.as_ref()?;
+    if cache.custom_path == *normalized_custom {
+        Some(cache.probe.clone())
+    } else {
+        None
+    }
+}
+
+async fn ensure_probed(state: &VodAudioProxyState, custom_path: Option<String>) -> Option<FfmpegProbe> {
+    let normalized_custom = normalize_custom_path(custom_path);
     {
         let cached = state
             .probe
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        if let Some(probe) = cached.as_ref() {
-            return Some(probe.clone());
+        if let Some(hit) = cached_probe_hit(&cached, &normalized_custom) {
+            return hit;
         }
     }
-    let probe = resolve_and_probe_ffmpeg().await;
-    if let Some(probe) = probe.clone() {
-        let mut cached = state
-            .probe
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        *cached = Some(probe);
-    }
+    let probe = resolve_and_probe_ffmpeg(normalized_custom.as_deref()).await;
+    let mut cached = state
+        .probe
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    *cached = Some(CachedProbeResolution {
+        custom_path: normalized_custom,
+        probe: probe.clone(),
+    });
     probe
 }
 
@@ -759,7 +789,20 @@ async fn handle_live(
 
     // Fresh channel per client; storing the sender ends any previous one.
     let (sender, mut receiver) = mpsc::channel::<Bytes>(OUTPUT_CHANNEL_CAPACITY);
-    set_current_client(&session, sender);
+    set_current_client(&session, sender.clone());
+
+    // A teardown racing the store must not leave a dead sender in place.
+    if session.torn_down.load(Ordering::SeqCst) {
+        let mut guard = session
+            .current_client
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if guard.as_ref().is_some_and(|current| current.same_channel(&sender)) {
+            *guard = None;
+        }
+        drop(guard);
+        return cors_response(StatusCode::NOT_FOUND, "session is no longer active");
+    }
 
     let body_stream = futures_util::stream::poll_fn(move |cx| {
         receiver
@@ -812,12 +855,12 @@ fn stop_after_client_disconnect(session: &VodAudioSession) {
     }
     session.blocked_on_send.store(false, Ordering::SeqCst);
     session.torn_down.store(true, Ordering::SeqCst);
+    session.client_gone.store(true, Ordering::SeqCst);
     session.kill_notify.notify_one();
     session.client_notify.notify_one();
 }
 
-// Backpressure ffmpeg until a client is ready. Dropping bytes here corrupts the
-// transport stream header on first mount and creates a discontinuity on reconnect.
+// Dropped bytes here would corrupt the TS header.
 async fn send_to_current_client(session: &Arc<VodAudioSession>, chunk: Bytes) {
     send_to_current_client_with_timeout(session, chunk, CLIENT_BACKPRESSURE_TIMEOUT).await;
 }
@@ -833,8 +876,7 @@ async fn send_to_current_client_with_timeout(
             return;
         }
 
-        // Create the waiter before inspecting the sender. A connection racing
-        // with this check leaves a stored permit, so the first chunk cannot hang.
+        // Waiter before sender read so a racing connect isn't missed.
         let client_changed = session.client_notify.notified();
         let sender = {
             let guard = session
@@ -844,8 +886,7 @@ async fn send_to_current_client_with_timeout(
             guard.clone()
         };
 
-        // Waiting for a client or its channel capacity is downstream
-        // backpressure, not an ffmpeg stdout stall.
+        // Downstream backpressure, not an ffmpeg stall.
         session.blocked_on_send.store(true, Ordering::SeqCst);
         let Some(sender) = sender else {
             if tokio::time::timeout(wait_timeout, client_changed).await.is_err() {
@@ -869,8 +910,7 @@ async fn send_to_current_client_with_timeout(
                     if still_current {
                         return;
                     }
-                    // A replacement raced with the send. Forward the same
-                    // chunk to the new client before reading another one.
+                    // Replacement raced the send; resend the chunk to it.
                     continue;
                 }
                 let mut guard = session
@@ -882,8 +922,7 @@ async fn send_to_current_client_with_timeout(
                 }
             }
             _ = client_changed => {
-                // A replacement client must receive this same chunk. Cancelling
-                // mpsc::Sender::send before it wins the select does not enqueue it.
+                // A cancelled send never enqueued; the loop resends.
             }
             _ = tokio::time::sleep(wait_timeout) => {
                 stop_after_client_disconnect(session);
@@ -990,6 +1029,7 @@ async fn run_watchdog(
             let _ = child.start_kill();
             let _ = child.wait().await;
             teardown_io(&session).await;
+            emit_client_timeout_if_disconnected(&app, &session).await;
             return;
         }
         _ = tokio::time::sleep(STARTUP_SILENCE_TIMEOUT) => {
@@ -1028,6 +1068,7 @@ async fn run_watchdog(
                 let _ = child.start_kill();
                 let _ = child.wait().await;
                 teardown_io(&session).await;
+                emit_client_timeout_if_disconnected(&app, &session).await;
                 return;
             }
         },
@@ -1063,11 +1104,35 @@ async fn finish_with_error(app: &AppHandle, session: &Arc<VodAudioSession>, deta
     }
 }
 
+async fn emit_client_timeout_if_disconnected(app: &AppHandle, session: &Arc<VodAudioSession>) {
+    if !session.client_gone.load(Ordering::SeqCst) {
+        return;
+    }
+    let _ = app.emit(
+        ERROR_EVENT,
+        json!({
+            "sessionId": session.session_id,
+            "detail": format!(
+                "TIMEOUT:playback client disconnected for {}s{}",
+                CLIENT_BACKPRESSURE_TIMEOUT.as_secs(),
+                stderr_tail_suffix(session)
+            ),
+        }),
+    );
+}
+
 // --- Teardown ---
 
 /// Never blocks on the child mutex; killing goes through kill_notify instead.
 async fn teardown_io(session: &Arc<VodAudioSession>) {
     session.torn_down.store(true, Ordering::SeqCst);
+    {
+        let mut guard = session
+            .current_client
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        guard.take();
+    }
     session.kill_notify.notify_one();
     session.client_notify.notify_one();
 
@@ -1368,6 +1433,55 @@ mod tests {
     }
 
     #[test]
+    fn normalize_custom_path_trims_and_drops_blank() {
+        assert_eq!(normalize_custom_path(None), None);
+        assert_eq!(normalize_custom_path(Some("".to_string())), None);
+        assert_eq!(normalize_custom_path(Some("   ".to_string())), None);
+        assert_eq!(
+            normalize_custom_path(Some("  /usr/bin/ffmpeg  ".to_string())),
+            Some("/usr/bin/ffmpeg".to_string())
+        );
+    }
+
+    #[test]
+    fn cached_probe_hit_returns_none_without_a_cache_entry() {
+        assert!(cached_probe_hit(&None, &None).is_none());
+    }
+
+    #[test]
+    fn cached_probe_hit_returns_the_cached_negative_outcome_without_reprobing() {
+        let cached = Some(CachedProbeResolution {
+            custom_path: None,
+            probe: None,
+        });
+        assert_eq!(cached_probe_hit(&cached, &None), Some(None));
+    }
+
+    #[test]
+    fn cached_probe_hit_returns_the_cached_probe_when_the_path_matches() {
+        let probe = FfmpegProbe {
+            path: "/usr/bin/ffmpeg".to_string(),
+        };
+        let cached = Some(CachedProbeResolution {
+            custom_path: Some("/usr/bin/ffmpeg".to_string()),
+            probe: Some(probe.clone()),
+        });
+        assert_eq!(
+            cached_probe_hit(&cached, &Some("/usr/bin/ffmpeg".to_string())),
+            Some(Some(probe))
+        );
+    }
+
+    #[test]
+    fn cached_probe_hit_returns_none_when_the_custom_path_changed() {
+        let cached = Some(CachedProbeResolution {
+            custom_path: Some("/usr/bin/ffmpeg".to_string()),
+            probe: None,
+        });
+        assert!(cached_probe_hit(&cached, &Some("/opt/ffmpeg/ffmpeg".to_string())).is_none());
+    }
+
+    #[test]
     fn stderr_tail_suffix_is_empty_when_no_lines_captured() {
         let session = Arc::new(VodAudioSession {
             session_id: "sess".to_string(),
@@ -1375,6 +1489,7 @@ mod tests {
             user_agent: None,
             authorization: None,
             torn_down: AtomicBool::new(false),
+            client_gone: AtomicBool::new(false),
             current_client: Mutex::new(None),
             client_notify: Notify::new(),
             stderr_tail: Mutex::new(VecDeque::new()),
@@ -1399,6 +1514,7 @@ mod tests {
             user_agent: None,
             authorization: None,
             torn_down: AtomicBool::new(false),
+            client_gone: AtomicBool::new(false),
             current_client: Mutex::new(None),
             client_notify: Notify::new(),
             stderr_tail: Mutex::new(tail),
@@ -1422,6 +1538,7 @@ mod tests {
             user_agent: None,
             authorization: None,
             torn_down: AtomicBool::new(false),
+            client_gone: AtomicBool::new(false),
             current_client: Mutex::new(None),
             client_notify: Notify::new(),
             stderr_tail: Mutex::new(VecDeque::new()),
@@ -1569,7 +1686,7 @@ mod tests {
         tokio::time::timeout(Duration::from_millis(500), send_task)
             .await
             .expect("teardown should wake client delivery")
-        .expect("delivery task should not panic");
+            .expect("delivery task should not panic");
         assert!(!session.blocked_on_send.load(Ordering::SeqCst));
     }
 
@@ -1598,6 +1715,7 @@ mod tests {
             .await
             .expect("client timeout must wake the watchdog");
         assert!(session.torn_down.load(Ordering::SeqCst));
+        assert!(session.client_gone.load(Ordering::SeqCst));
         assert!(!session.blocked_on_send.load(Ordering::SeqCst));
     }
 

--- a/src-tauri/src/vod_audio_proxy.rs
+++ b/src-tauri/src/vod_audio_proxy.rs
@@ -27,6 +27,7 @@ const OUTPUT_CHANNEL_CAPACITY: usize = 256;
 const STDERR_RING_CAPACITY: usize = 10;
 const STARTUP_SILENCE_TIMEOUT: Duration = Duration::from_secs(10);
 const STDOUT_STALL_TIMEOUT: Duration = Duration::from_secs(20);
+const CLIENT_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(10);
 const STALL_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 // --- State ---
@@ -39,6 +40,9 @@ type SessionMap = Arc<Mutex<HashMap<String, Arc<VodAudioSession>>>>;
 struct FfmpegProbe {
     path: String,
     demuxers_ok: bool,
+    // Matroska commonly omits video DTS; these decoders let FFmpeg infer the
+    // H.264/HEVC reorder delay while probing before stream-copying the video.
+    video_decoders_ok: bool,
 }
 
 struct ServerHandle {
@@ -65,6 +69,8 @@ struct VodAudioSession {
     torn_down: AtomicBool,
     // New GET replaces the previous client's sender.
     current_client: Mutex<Option<mpsc::Sender<Bytes>>>,
+    // Wakes stdout delivery when the first client connects or a GET replaces it.
+    client_notify: Notify,
     stderr_tail: Mutex<VecDeque<String>>,
     // Held only until run_watchdog takes ownership.
     child: tokio::sync::Mutex<Option<Child>>,
@@ -85,7 +91,10 @@ struct VodAudioSession {
 #[tauri::command]
 pub async fn vod_audio_remux_available(app: AppHandle) -> bool {
     let state = app.state::<VodAudioProxyState>();
-    ensure_probed(&state).await.map(|probe| probe.demuxers_ok).unwrap_or(false)
+    ensure_probed(&state)
+        .await
+        .map(|probe| probe.demuxers_ok && probe.video_decoders_ok)
+        .unwrap_or(false)
 }
 
 #[derive(Debug, Serialize)]
@@ -121,7 +130,12 @@ pub async fn register_vod_audio_remux(
 
     let ffmpeg_path = match ensure_probed(&state).await {
         Some(probe) => probe.path,
-        None => return Err("NOT_FOUND:ffmpeg binary not found".to_string()),
+        None => {
+            return Err(
+                "NOT_FOUND:ffmpeg with Matroska/MOV demuxers and H.264/HEVC decoders not found"
+                    .to_string(),
+            )
+        }
     };
 
     let port = ensure_server_started(&state).await?;
@@ -134,6 +148,7 @@ pub async fn register_vod_audio_remux(
         authorization: if is_loopback { None } else { authorization },
         torn_down: AtomicBool::new(false),
         current_client: Mutex::new(None),
+        client_notify: Notify::new(),
         stderr_tail: Mutex::new(VecDeque::new()),
         child: tokio::sync::Mutex::new(None),
         kill_notify: Notify::new(),
@@ -321,8 +336,12 @@ fn build_ffmpeg_args(input_url: &str, audio_stream_index: u32, start_seconds: f6
         "-loglevel".to_string(),
         "warning".to_string(),
     ];
-    // -ss must precede -i for input seeking.
+    // -ss must precede -i for input seeking. The video is stream-copied, so
+    // preserve its keyframe pre-roll in transcoded audio as well. Otherwise
+    // accurate seeking drops that pre-roll only from audio and leaves the MSE
+    // player correcting a multi-second A/V timestamp gap after a track switch.
     if start_seconds > 0.1 {
+        args.push("-noaccurate_seek".to_string());
         args.push("-ss".to_string());
         args.push(format!("{start_seconds}"));
     }
@@ -340,7 +359,7 @@ fn build_ffmpeg_args(input_url: &str, audio_stream_index: u32, start_seconds: f6
                 "-c:a",
                 "aac",
                 "-af",
-                "aresample=async=1:first_pts=0",
+                "aresample=async=1",
                 "-ac",
                 "2",
                 "-b:a",
@@ -381,21 +400,87 @@ fn classify_io_error(err: &std::io::Error) -> String {
     }
 }
 
+fn ffmpeg_path_candidates<F>(
+    path_var: &std::ffi::OsStr,
+    binary_name: &str,
+    is_file: F,
+) -> Vec<String>
+where
+    F: Fn(&std::path::Path) -> bool,
+{
+    std::env::split_paths(path_var)
+        .map(|directory| directory.join(binary_name))
+        .filter(|candidate| is_file(candidate))
+        .map(|candidate| candidate.to_string_lossy().into_owned())
+        .collect()
+}
+
+fn same_ffmpeg_candidate(left: &str, right: &str) -> bool {
+    #[cfg(windows)]
+    {
+        left.eq_ignore_ascii_case(right)
+    }
+    #[cfg(not(windows))]
+    {
+        left == right
+    }
+}
+
 fn ffmpeg_candidates() -> Vec<String> {
-    let mut candidates = Vec::new();
+    let mut candidates: Vec<String> = Vec::new();
+    let mut push_candidate = |candidate: String| {
+        if !candidates
+            .iter()
+            .any(|existing| same_ffmpeg_candidate(existing, &candidate))
+        {
+            candidates.push(candidate);
+        }
+    };
     if let Ok(exe_path) = std::env::current_exe() {
         if let Some(parent) = exe_path.parent() {
-            let sidecar_name = if cfg!(windows) { "ffmpeg.exe" } else { "ffmpeg" };
-            candidates.push(parent.join(sidecar_name).to_string_lossy().into_owned());
+            let sidecar_name = if cfg!(windows) {
+                "ffmpeg.exe"
+            } else {
+                "ffmpeg"
+            };
+            push_candidate(parent.join(sidecar_name).to_string_lossy().into_owned());
         }
     }
-    candidates.push("ffmpeg".to_string());
+
+    // Cargo/Tauri prepend their target directory to PATH in development. A
+    // stale local sidecar there can shadow a decoder-capable system ffmpeg;
+    // enumerate every PATH entry so capability probing can continue to the
+    // next match instead of stopping at the shadowing executable.
+    if let Some(path_var) = std::env::var_os("PATH") {
+        let binary_name = if cfg!(windows) {
+            "ffmpeg.exe"
+        } else {
+            "ffmpeg"
+        };
+        for candidate in ffmpeg_path_candidates(&path_var, binary_name, |path| path.is_file()) {
+            push_candidate(candidate);
+        }
+    }
+
+    // Keep the bare command as a final fallback for platforms where PATH
+    // lookup is virtual or the environment changes between probes.
+    push_candidate("ffmpeg".to_string());
     candidates
 }
 
 fn demuxers_support_matroska_and_mov(stdout: &str) -> bool {
     let lower = stdout.to_lowercase();
     lower.contains("matroska") && lower.contains("mov")
+}
+
+fn decoders_support_video_timestamp_inference(stdout: &str) -> bool {
+    let has_decoder = |name: &str| {
+        stdout.lines().any(|line| {
+            let fields: Vec<_> = line.split_whitespace().collect();
+            fields.get(1).is_some_and(|field| field.eq_ignore_ascii_case(name))
+        })
+    };
+    has_decoder("h264") && has_decoder("hevc")
 }
 
 async fn probe_demuxers(path: &str) -> Result<String, String> {
@@ -418,13 +503,43 @@ async fn probe_demuxers(path: &str) -> Result<String, String> {
     }
 }
 
+async fn probe_decoders(path: &str) -> Result<String, String> {
+    let mut command = TokioCommand::new(path);
+    command
+        .args(["-hide_banner", "-decoders"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    #[cfg(windows)]
+    {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    let child = command.spawn().map_err(|e| classify_io_error(&e))?;
+    match tokio::time::timeout(Duration::from_millis(DETECT_TIMEOUT_MS), child.wait_with_output()).await {
+        Ok(Ok(output)) => Ok(String::from_utf8_lossy(&output.stdout).into_owned()),
+        Ok(Err(e)) => Err(format!("OTHER:{e}")),
+        Err(_) => Err(format!("TIMEOUT:{path} did not exit within {DETECT_TIMEOUT_MS}ms")),
+    }
+}
+
 async fn resolve_and_probe_ffmpeg() -> Option<FfmpegProbe> {
     for candidate in ffmpeg_candidates() {
-        if let Ok(stdout) = probe_demuxers(&candidate).await {
-            return Some(FfmpegProbe {
-                path: candidate,
-                demuxers_ok: demuxers_support_matroska_and_mov(&stdout),
-            });
+        let Ok(demuxers_stdout) = probe_demuxers(&candidate).await else {
+            continue;
+        };
+        let demuxers_ok = demuxers_support_matroska_and_mov(&demuxers_stdout);
+        let video_decoders_ok = probe_decoders(&candidate)
+            .await
+            .map(|stdout| decoders_support_video_timestamp_inference(&stdout))
+            .unwrap_or(false);
+        let probe = FfmpegProbe {
+            path: candidate,
+            demuxers_ok,
+            video_decoders_ok,
+        };
+        if demuxers_ok && video_decoders_ok {
+            return Some(probe);
         }
     }
     None
@@ -638,16 +753,13 @@ async fn handle_live(
     if session.session_id != session_id {
         return cors_response(StatusCode::NOT_FOUND, "unknown session");
     }
+    if session.torn_down.load(Ordering::SeqCst) {
+        return cors_response(StatusCode::NOT_FOUND, "session is no longer active");
+    }
 
     // Fresh channel per client; storing the sender ends any previous one.
     let (sender, mut receiver) = mpsc::channel::<Bytes>(OUTPUT_CHANNEL_CAPACITY);
-    {
-        let mut guard = session
-            .current_client
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        *guard = Some(sender);
-    }
+    set_current_client(&session, sender);
 
     let body_stream = futures_util::stream::poll_fn(move |cx| {
         receiver
@@ -679,29 +791,104 @@ fn mark_activity(session: &VodAudioSession) {
     *last_activity = Instant::now();
 }
 
-// Discards the chunk if no client is connected; stdout must still drain.
-async fn send_to_current_client(session: &Arc<VodAudioSession>, chunk: Bytes) {
-    let sender = {
-        let guard = session
-            .current_client
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        guard.clone()
-    };
-    let Some(sender) = sender else {
-        return;
-    };
-    // Blocked here means the HTTP consumer is slow, not that ffmpeg stalled.
-    session.blocked_on_send.store(true, Ordering::SeqCst);
-    let send_result = sender.send(chunk).await;
-    session.blocked_on_send.store(false, Ordering::SeqCst);
-    if send_result.is_err() {
+fn set_current_client(session: &VodAudioSession, sender: mpsc::Sender<Bytes>) {
+    {
         let mut guard = session
             .current_client
             .lock()
             .unwrap_or_else(|poison| poison.into_inner());
-        if guard.as_ref().is_some_and(|current| current.same_channel(&sender)) {
-            *guard = None;
+        *guard = Some(sender);
+    }
+    session.client_notify.notify_one();
+}
+
+fn stop_after_client_disconnect(session: &VodAudioSession) {
+    {
+        let mut guard = session
+            .current_client
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        *guard = None;
+    }
+    session.blocked_on_send.store(false, Ordering::SeqCst);
+    session.torn_down.store(true, Ordering::SeqCst);
+    session.kill_notify.notify_one();
+    session.client_notify.notify_one();
+}
+
+// Backpressure ffmpeg until a client is ready. Dropping bytes here corrupts the
+// transport stream header on first mount and creates a discontinuity on reconnect.
+async fn send_to_current_client(session: &Arc<VodAudioSession>, chunk: Bytes) {
+    send_to_current_client_with_timeout(session, chunk, CLIENT_BACKPRESSURE_TIMEOUT).await;
+}
+
+async fn send_to_current_client_with_timeout(
+    session: &Arc<VodAudioSession>,
+    chunk: Bytes,
+    wait_timeout: Duration,
+) {
+    loop {
+        if session.torn_down.load(Ordering::SeqCst) {
+            session.blocked_on_send.store(false, Ordering::SeqCst);
+            return;
+        }
+
+        // Create the waiter before inspecting the sender. A connection racing
+        // with this check leaves a stored permit, so the first chunk cannot hang.
+        let client_changed = session.client_notify.notified();
+        let sender = {
+            let guard = session
+                .current_client
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            guard.clone()
+        };
+
+        // Waiting for a client or its channel capacity is downstream
+        // backpressure, not an ffmpeg stdout stall.
+        session.blocked_on_send.store(true, Ordering::SeqCst);
+        let Some(sender) = sender else {
+            if tokio::time::timeout(wait_timeout, client_changed).await.is_err() {
+                stop_after_client_disconnect(session);
+                return;
+            }
+            continue;
+        };
+
+        tokio::select! {
+            send_result = sender.send(chunk.clone()) => {
+                session.blocked_on_send.store(false, Ordering::SeqCst);
+                if send_result.is_ok() {
+                    let still_current = {
+                        let guard = session
+                            .current_client
+                            .lock()
+                            .unwrap_or_else(|poison| poison.into_inner());
+                        guard.as_ref().is_some_and(|current| current.same_channel(&sender))
+                    };
+                    if still_current {
+                        return;
+                    }
+                    // A replacement raced with the send. Forward the same
+                    // chunk to the new client before reading another one.
+                    continue;
+                }
+                let mut guard = session
+                    .current_client
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                if guard.as_ref().is_some_and(|current| current.same_channel(&sender)) {
+                    *guard = None;
+                }
+            }
+            _ = client_changed => {
+                // A replacement client must receive this same chunk. Cancelling
+                // mpsc::Sender::send before it wins the select does not enqueue it.
+            }
+            _ = tokio::time::sleep(wait_timeout) => {
+                stop_after_client_disconnect(session);
+                return;
+            }
         }
     }
 }
@@ -802,6 +989,7 @@ async fn run_watchdog(
         _ = session.kill_notify.notified() => {
             let _ = child.start_kill();
             let _ = child.wait().await;
+            teardown_io(&session).await;
             return;
         }
         _ = tokio::time::sleep(STARTUP_SILENCE_TIMEOUT) => {
@@ -839,6 +1027,7 @@ async fn run_watchdog(
             _ = session.kill_notify.notified() => {
                 let _ = child.start_kill();
                 let _ = child.wait().await;
+                teardown_io(&session).await;
                 return;
             }
         },
@@ -880,6 +1069,7 @@ async fn finish_with_error(app: &AppHandle, session: &Arc<VodAudioSession>, deta
 async fn teardown_io(session: &Arc<VodAudioSession>) {
     session.torn_down.store(true, Ordering::SeqCst);
     session.kill_notify.notify_one();
+    session.client_notify.notify_one();
 
     if let Ok(mut guard) = session.child.try_lock() {
         if let Some(mut child) = guard.take() {
@@ -937,6 +1127,7 @@ pub fn shutdown(state: &VodAudioProxyState) {
     for session in sessions {
         session.torn_down.store(true, Ordering::SeqCst);
         session.kill_notify.notify_one();
+        session.client_notify.notify_one();
 
         if let Ok(mut child_guard) = session.child.try_lock() {
             if let Some(child) = child_guard.as_mut() {
@@ -1025,7 +1216,7 @@ mod tests {
                 "-c:a",
                 "aac",
                 "-af",
-                "aresample=async=1:first_pts=0",
+                "aresample=async=1",
                 "-ac",
                 "2",
                 "-b:a",
@@ -1046,8 +1237,16 @@ mod tests {
     #[test]
     fn build_ffmpeg_args_places_ss_before_i_when_start_seconds_is_meaningful() {
         let args = build_ffmpeg_args("http://127.0.0.1:9000/forward/abc/stream", 0, 12.5, false);
+        let no_accurate_seek_index = args
+            .iter()
+            .position(|arg| arg == "-noaccurate_seek")
+            .expect("-noaccurate_seek must be present");
         let ss_index = args.iter().position(|arg| arg == "-ss").expect("-ss must be present");
         let i_index = args.iter().position(|arg| arg == "-i").expect("-i must be present");
+        assert!(
+            no_accurate_seek_index < ss_index,
+            "-noaccurate_seek must precede -ss"
+        );
         assert!(ss_index < i_index, "-ss must precede -i for input seeking");
         assert_eq!(args[ss_index + 1], "12.5");
     }
@@ -1056,6 +1255,10 @@ mod tests {
     fn build_ffmpeg_args_omits_ss_for_negligible_start_seconds() {
         let args = build_ffmpeg_args("http://127.0.0.1:9000/forward/abc/stream", 0, 0.05, false);
         assert!(!args.iter().any(|arg| arg == "-ss"), "-ss must be omitted below the threshold");
+        assert!(
+            !args.iter().any(|arg| arg == "-noaccurate_seek"),
+            "-noaccurate_seek must be omitted when no input seek is performed"
+        );
     }
 
     #[test]
@@ -1114,10 +1317,54 @@ mod tests {
     }
 
     #[test]
+    fn ffmpeg_path_candidates_keep_searching_after_a_shadowed_binary() {
+        let shadowed_dir = std::path::PathBuf::from("shadowed");
+        let working_dir = std::path::PathBuf::from("working");
+        let missing_dir = std::path::PathBuf::from("missing");
+        let path_var = std::env::join_paths([&shadowed_dir, &working_dir, &missing_dir])
+            .expect("test PATH entries should be joinable");
+        let binary_name = if cfg!(windows) {
+            "ffmpeg.exe"
+        } else {
+            "ffmpeg"
+        };
+
+        let candidates = ffmpeg_path_candidates(&path_var, binary_name, |candidate| {
+            candidate
+                .parent()
+                .is_some_and(|parent| parent != missing_dir)
+        });
+        let candidates: Vec<std::path::PathBuf> = candidates.into_iter().map(Into::into).collect();
+
+        assert_eq!(
+            candidates,
+            vec![
+                shadowed_dir.join(binary_name),
+                working_dir.join(binary_name)
+            ]
+        );
+    }
+
+    #[test]
+    fn ffmpeg_candidate_comparison_matches_filesystem_case_rules() {
+        #[cfg(windows)]
+        assert!(same_ffmpeg_candidate("C:\\FFMPEG\\ffmpeg.exe", "c:\\ffmpeg\\FFMPEG.EXE"));
+        #[cfg(not(windows))]
+        assert!(!same_ffmpeg_candidate("/opt/FFmpeg/ffmpeg", "/opt/ffmpeg/ffmpeg"));
+    }
+
+    #[test]
     fn demuxers_support_matroska_and_mov_requires_both() {
         let listing = " D  matroska,webm      Matroska / WebM\n D  mov,mp4,m4a,3gp     QuickTime / MOV\n";
         assert!(demuxers_support_matroska_and_mov(listing));
         assert!(!demuxers_support_matroska_and_mov(" D  mpegts     MPEG-TS"));
+    }
+
+    #[test]
+    fn decoders_support_video_timestamp_inference_requires_h264_and_hevc() {
+        let listing = " VFS..D h264                 H.264 / AVC\n VFS..D hevc                 H.265 / HEVC\n";
+        assert!(decoders_support_video_timestamp_inference(listing));
+        assert!(!decoders_support_video_timestamp_inference(" VFS..D h264 H.264 / AVC\n"));
     }
 
     #[test]
@@ -1129,6 +1376,7 @@ mod tests {
             authorization: None,
             torn_down: AtomicBool::new(false),
             current_client: Mutex::new(None),
+            client_notify: Notify::new(),
             stderr_tail: Mutex::new(VecDeque::new()),
             child: tokio::sync::Mutex::new(None),
             kill_notify: Notify::new(),
@@ -1152,6 +1400,7 @@ mod tests {
             authorization: None,
             torn_down: AtomicBool::new(false),
             current_client: Mutex::new(None),
+            client_notify: Notify::new(),
             stderr_tail: Mutex::new(tail),
             child: tokio::sync::Mutex::new(None),
             kill_notify: Notify::new(),
@@ -1174,6 +1423,7 @@ mod tests {
             authorization: None,
             torn_down: AtomicBool::new(false),
             current_client: Mutex::new(None),
+            client_notify: Notify::new(),
             stderr_tail: Mutex::new(VecDeque::new()),
             child: tokio::sync::Mutex::new(None),
             kill_notify: Notify::new(),
@@ -1234,6 +1484,121 @@ mod tests {
             .unwrap_or_else(|poison| poison.into_inner());
         assert_eq!(sessions.len(), 1, "the losing registration must not orphan a session");
         assert!(sessions.contains_key(&active_id));
+    }
+
+    async fn wait_until_output_is_backpressured(session: &VodAudioSession) {
+        for _ in 0..100 {
+            if session.blocked_on_send.load(Ordering::SeqCst) {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("output delivery did not enter downstream backpressure");
+    }
+
+    #[tokio::test]
+    async fn output_waits_for_first_client_without_dropping_the_chunk() {
+        let session = test_vod_audio_session();
+        let expected = Bytes::from_static(b"transport stream header");
+        let sending_session = session.clone();
+        let sending_chunk = expected.clone();
+        let send_task = tokio::spawn(async move {
+            send_to_current_client(&sending_session, sending_chunk).await;
+        });
+
+        wait_until_output_is_backpressured(&session).await;
+        assert!(!send_task.is_finished(), "the chunk must wait for the first HTTP client");
+
+        let (sender, mut receiver) = mpsc::channel(1);
+        set_current_client(&session, sender);
+
+        let received = tokio::time::timeout(Duration::from_millis(500), receiver.recv())
+            .await
+            .expect("the client should receive the waiting chunk")
+            .expect("the client channel should remain open");
+        assert_eq!(received, expected);
+        tokio::time::timeout(Duration::from_millis(500), send_task)
+            .await
+            .expect("delivery should finish after the client connects")
+            .expect("delivery task should not panic");
+    }
+
+    #[tokio::test]
+    async fn replacement_client_receives_a_chunk_blocked_on_the_old_client() {
+        let session = test_vod_audio_session();
+        let (old_sender, _old_receiver) = mpsc::channel(1);
+        old_sender
+            .send(Bytes::from_static(b"already queued"))
+            .await
+            .expect("old channel should accept its first chunk");
+        set_current_client(&session, old_sender);
+
+        let expected = Bytes::from_static(b"rerouted chunk");
+        let sending_session = session.clone();
+        let sending_chunk = expected.clone();
+        let send_task = tokio::spawn(async move {
+            send_to_current_client(&sending_session, sending_chunk).await;
+        });
+        wait_until_output_is_backpressured(&session).await;
+
+        let (new_sender, mut new_receiver) = mpsc::channel(1);
+        set_current_client(&session, new_sender);
+
+        let received = tokio::time::timeout(Duration::from_millis(500), new_receiver.recv())
+            .await
+            .expect("replacement client should receive the blocked chunk")
+            .expect("replacement channel should remain open");
+        assert_eq!(received, expected);
+        tokio::time::timeout(Duration::from_millis(500), send_task)
+            .await
+            .expect("delivery should finish through the replacement client")
+            .expect("delivery task should not panic");
+    }
+
+    #[tokio::test]
+    async fn teardown_wakes_output_waiting_for_a_client() {
+        let session = test_vod_audio_session();
+        let sending_session = session.clone();
+        let send_task = tokio::spawn(async move {
+            send_to_current_client(&sending_session, Bytes::from_static(b"pending")).await;
+        });
+        wait_until_output_is_backpressured(&session).await;
+
+        teardown_io(&session).await;
+
+        tokio::time::timeout(Duration::from_millis(500), send_task)
+            .await
+            .expect("teardown should wake client delivery")
+        .expect("delivery task should not panic");
+        assert!(!session.blocked_on_send.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn disconnected_client_timeout_stops_output_backpressure() {
+        let session = test_vod_audio_session();
+        let (sender, receiver) = mpsc::channel(1);
+        drop(receiver);
+        set_current_client(&session, sender);
+        let kill_wakeup = session.kill_notify.notified();
+        let sending_session = session.clone();
+        let send_task = tokio::spawn(async move {
+            send_to_current_client_with_timeout(
+                &sending_session,
+                Bytes::from_static(b"orphaned"),
+                Duration::from_millis(10),
+            )
+            .await;
+        });
+
+        tokio::time::timeout(Duration::from_millis(500), send_task)
+            .await
+            .expect("disconnected delivery must have a finite wait")
+            .expect("delivery task should not panic");
+        tokio::time::timeout(Duration::from_millis(500), kill_wakeup)
+            .await
+            .expect("client timeout must wake the watchdog");
+        assert!(session.torn_down.load(Ordering::SeqCst));
+        assert!(!session.blocked_on_send.load(Ordering::SeqCst));
     }
 
     // Regression test: teardown_io blocking while the watchdog owned the child.

--- a/src/scripts/lib/audio-tracks.ts
+++ b/src/scripts/lib/audio-tracks.ts
@@ -119,10 +119,8 @@ function shakaChannelSuffix(channelsCount: number | null | undefined): string {
   return ""
 }
 
-// Shaka clears forward buffer when changing audio. Retain roughly two common
-// four-second segments so the replacement audio can arrive without starving
-// playback; Shaka itself warns that a zero safe margin can cause hiccups.
-const SHAKA_AUDIO_SWITCH_SAFE_MARGIN_SECONDS = 8
+// Zero safe margin can cause a rebuffer hiccup (Shaka docs).
+const SHAKA_AUDIO_SWITCH_SAFE_MARGIN_SECONDS = 4
 
 export function createShakaAudioSource(player: any): AudioTrackSource {
   const listeners = new Set<() => void>()

--- a/src/scripts/lib/audio-tracks.ts
+++ b/src/scripts/lib/audio-tracks.ts
@@ -119,6 +119,11 @@ function shakaChannelSuffix(channelsCount: number | null | undefined): string {
   return ""
 }
 
+// Shaka clears forward buffer when changing audio. Retain roughly two common
+// four-second segments so the replacement audio can arrive without starving
+// playback; Shaka itself warns that a zero safe margin can cause hiccups.
+const SHAKA_AUDIO_SWITCH_SAFE_MARGIN_SECONDS = 8
+
 export function createShakaAudioSource(player: any): AudioTrackSource {
   const listeners = new Set<() => void>()
 
@@ -180,7 +185,7 @@ export function createShakaAudioSource(player: any): AudioTrackSource {
         if (usesAudioTrackApi()) {
           const tracks: any[] = player.getAudioTracks() ?? []
           const track = tracks.find((candidate, index) => String(candidate.id ?? index) === id)
-          if (track) player.selectAudioTrack(track)
+          if (track) player.selectAudioTrack(track, SHAKA_AUDIO_SWITCH_SAFE_MARGIN_SECONDS)
           return
         }
         const variants: any[] = player.getVariantTracks?.() ?? []
@@ -194,7 +199,7 @@ export function createShakaAudioSource(player: any): AudioTrackSource {
         } else {
           player.configure({ abr: { enabled: false } })
         }
-        player.selectVariantTrack(variant, true)
+        player.selectVariantTrack(variant, true, SHAKA_AUDIO_SWITCH_SAFE_MARGIN_SECONDS)
       } catch {}
     },
     subscribe(listener) {

--- a/src/scripts/lib/player-runtime.ts
+++ b/src/scripts/lib/player-runtime.ts
@@ -1435,6 +1435,13 @@ async function attachMpegts(
     const config: Record<string, unknown> = {}
     if (useTauriLoader) config.customLoader = createTauriStreamLoaderClass(mpegts)
     if (authorization) config.headers = { Authorization: authorization }
+    if (!isLive) {
+      try {
+        const hostname = new URL(cleanUrl).hostname
+        // Lazy-load aborts kill stateful local proxy sessions.
+        if (hostname === "127.0.0.1" || hostname === "localhost") config.lazyLoad = false
+      } catch {}
+    }
     const mediaDataSource: Record<string, unknown> = { type: "mpegts", isLive, url: cleanUrl }
     if (!isLive && Number.isFinite(durationSeconds) && (durationSeconds as number) > 0) {
       mediaDataSource.duration = Math.round((durationSeconds as number) * 1000)

--- a/src/scripts/lib/player-runtime.ts
+++ b/src/scripts/lib/player-runtime.ts
@@ -1301,6 +1301,11 @@ function describeShakaError(detail: any): string {
   return `shaka:${label}:${code}${data ? " " + JSON.stringify(data) : ""}`
 }
 
+/** Converts mpegts.js' native absolute offset back to its relative timeline. */
+export function mpegtsRelativeTimestampOffset(nativeOffset: number, timelineOffset: number): number {
+  return nativeOffset - timelineOffset
+}
+
 async function attachMpegts(
   videoEl: HTMLVideoElement,
   url: string,
@@ -1377,7 +1382,12 @@ async function attachMpegts(
           const sourceBuffer = originalAdd(mime)
           try {
             Object.defineProperty(sourceBuffer, "timestampOffset", {
-              get() { return nativeDescriptor.get!.call(sourceBuffer) },
+              get() {
+                return mpegtsRelativeTimestampOffset(
+                  nativeDescriptor.get!.call(sourceBuffer),
+                  baseSeconds as number,
+                )
+              },
               set(value: number) { nativeDescriptor.set!.call(sourceBuffer, value + (baseSeconds as number)) },
             })
             nativeDescriptor.set!.call(sourceBuffer, baseSeconds as number)

--- a/src/scripts/lib/vod-audio-proxy.ts
+++ b/src/scripts/lib/vod-audio-proxy.ts
@@ -1,6 +1,7 @@
 // Desktop ffmpeg VOD audio-remux proxy client: one session at a time.
 
 import { log } from "@/scripts/lib/log.js"
+import { getFfmpegPath, SETTINGS_EVENT } from "@/scripts/lib/app-settings.js"
 
 export interface VodAudioRemuxOptions {
   url: string
@@ -36,7 +37,9 @@ let activeSessionId: string | null = null
 async function probeAvailability(): Promise<boolean> {
   try {
     const { invoke } = await import("@tauri-apps/api/core")
-    return !!(await invoke("vod_audio_remux_available"))
+    return !!(await invoke("vod_audio_remux_available", {
+      ffmpegPath: getFfmpegPath() || null,
+    }))
   } catch (err) {
     log.warn("[xt:vod-audio-proxy] availability check failed:", err)
     return false
@@ -47,6 +50,13 @@ export async function vodAudioRemuxAvailable(): Promise<boolean> {
   if (!vodAudioRemuxPlatformAvailable) return false
   if (!cachedAvailability) cachedAvailability = probeAvailability()
   return cachedAvailability
+}
+
+if (vodAudioRemuxPlatformAvailable && typeof document !== "undefined") {
+  document.addEventListener(SETTINGS_EVENT, (event: Event) => {
+    const detail = (event as CustomEvent)?.detail
+    if (detail?.key === "ffmpegPath") cachedAvailability = null
+  })
 }
 
 export async function startVodAudioRemux(
@@ -62,6 +72,7 @@ export async function startVodAudioRemux(
       audioStreamIndex: options.audioStreamIndex,
       startSeconds: options.startSeconds,
       transcodeAudio: options.transcodeAudio,
+      ffmpegPath: getFfmpegPath() || null,
     })) as { sessionId?: string; playbackUrl?: string }
     if (!result?.sessionId || !result?.playbackUrl) {
       throw new Error("register_vod_audio_remux returned an unexpected shape")

--- a/tests/audio-tracks.test.ts
+++ b/tests/audio-tracks.test.ts
@@ -201,7 +201,7 @@ describe("createShakaAudioSource", () => {
 
     source.select("b")
 
-    expect(player.selectAudioTrack).toHaveBeenCalledWith(tracks[1], 8)
+    expect(player.selectAudioTrack).toHaveBeenCalledWith(tracks[1], 4)
   })
 
   it("retains the same safe margin with Shaka's legacy variant API", () => {
@@ -222,7 +222,7 @@ describe("createShakaAudioSource", () => {
     source.select("b")
 
     expect(player.selectAudioLanguage).toHaveBeenCalledWith("it", undefined)
-    expect(player.selectVariantTrack).toHaveBeenCalledWith(variants[1], true, 8)
+    expect(player.selectVariantTrack).toHaveBeenCalledWith(variants[1], true, 4)
   })
 
   it("suppresses notify for an event whose track list signature is unchanged (video-only adaptation)", () => {

--- a/tests/audio-tracks.test.ts
+++ b/tests/audio-tracks.test.ts
@@ -191,6 +191,40 @@ function createFakeShakaPlayer(tracks: any[]) {
 }
 
 describe("createShakaAudioSource", () => {
+  it("retains a safe forward buffer while switching with the audio-track API", () => {
+    const tracks = [
+      { id: "a", label: "English", language: "en", active: true },
+      { id: "b", label: "Italian", language: "it", active: false },
+    ]
+    const player = createFakeShakaPlayer(tracks)
+    const source = createShakaAudioSource(player)
+
+    source.select("b")
+
+    expect(player.selectAudioTrack).toHaveBeenCalledWith(tracks[1], 8)
+  })
+
+  it("retains the same safe margin with Shaka's legacy variant API", () => {
+    const variants = [
+      { id: 10, audioId: "a", language: "en", roles: [], active: true },
+      { id: 20, audioId: "b", language: "it", roles: [], active: false },
+    ]
+    const player = {
+      getVariantTracks: () => variants,
+      selectAudioLanguage: vi.fn(),
+      selectVariantTrack: vi.fn(),
+      configure: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+    const source = createShakaAudioSource(player)
+
+    source.select("b")
+
+    expect(player.selectAudioLanguage).toHaveBeenCalledWith("it", undefined)
+    expect(player.selectVariantTrack).toHaveBeenCalledWith(variants[1], true, 8)
+  })
+
   it("suppresses notify for an event whose track list signature is unchanged (video-only adaptation)", () => {
     const tracks = [
       { id: "a", label: "English", language: "en", active: true },

--- a/tests/player-runtime.test.ts
+++ b/tests/player-runtime.test.ts
@@ -7,9 +7,17 @@ import {
   PlayerLaunchError,
   externalPlayersAvailable,
   androidMimeForUrl,
+  mpegtsRelativeTimestampOffset,
 } from "../src/scripts/lib/player-runtime"
 
 const SRC = "https://example.com/live/u/p/1.m3u8"
+
+describe("mpegtsRelativeTimestampOffset", () => {
+  it("rebases the native absolute offset before mpegts compares segment offsets", () => {
+    expect(mpegtsRelativeTimestampOffset(60.02, 60)).toBeCloseTo(0.02)
+    expect(mpegtsRelativeTimestampOffset(60, 60)).toBe(0)
+  })
+})
 
 describe("buildMpvArgs", () => {
   it("emits required flags and src last with no optional inputs", () => {


### PR DESCRIPTION
## Summary

- prevent VOD language switching from producing irregular video timestamps and apparent low framerate
- require Matroska/MOV demuxers plus H.264/HEVC decoder capability, while resolving every FFmpeg candidate on PATH so Cargo/Tauri's debug sidecar cannot shadow a usable system binary
- preserve the first MPEG-TS chunk across client reconnects and bound waits after a disconnected playback client
- fix mpegts.js relative timestamp offsets and add Shaka audio-switch buffer margin
- update the FFmpeg sidecar workflow and sanity checks for the required video decoders

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml` (105 passed, 1 ignored)
- `pnpm test` (720 passed)
- `pnpm build`
- IntelliJ targeted build succeeded

## Release follow-up

The upstream rolling `ffmpeg-sidecar-v2` release is still pinned to workflow commit `8515d59`, whose existing binaries predate the decoder additions. After merging this PR, run the `ffmpeg Sidecar` workflow and refresh `src/scripts/ffmpeg-sidecar-checksums.json` with `node src/scripts/ensure-ffmpeg-sidecar.mjs --update-pins` before cutting a packaged release.